### PR TITLE
Potential fix for code scanning alert no. 1: Loop bound injection

### DIFF
--- a/server/routes/chat.mjs
+++ b/server/routes/chat.mjs
@@ -16,7 +16,11 @@ function updateChat(f) {
 }
 
 function formatChat(n) {
-  return rooms[n]?.flatMap((x) => lodash.chunk(x, 16).map((x) => x.join("").padEnd(16, " "))) ?? [];
+  const room = rooms[n];
+  if (!Array.isArray(room)) {
+    return [];
+  }
+  return room.flatMap((x) => lodash.chunk(x, 16).map((x) => x.join("").padEnd(16, " ")));
 }
 
 const list_len = 7;


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/TI-32.Nameless/security/code-scanning/1](https://github.com/NanashiTheNameless/TI-32.Nameless/security/code-scanning/1)

To fix the issue, we need to ensure that the `rooms[n]` object is validated before it is processed in the `formatChat` function. Specifically, we should check that `rooms[n]` is an array before applying `flatMap` and `lodash.chunk`. If `rooms[n]` is not an array, we should return an empty array or handle the case appropriately. This validation ensures that the `.length` property cannot be maliciously manipulated to cause excessive iterations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
