### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "express": "^5.1.0",
     "lodash": "^4.17.21",
     "morgan": "^1.10.0",
-    "openai": "^5.10.1"
+    "openai": "^5.10.1",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/server/routes/images.mjs
+++ b/server/routes/images.mjs
@@ -2,6 +2,7 @@ import express from "express";
 import path from "path";
 import fs from "fs";
 import _ from "lodash";
+import rateLimit from "express-rate-limit";
 
 export function images() {
   const router = express.Router();
@@ -39,7 +40,12 @@ export function images() {
     res.send(image_list.join(""));
   });
 
-  router.get("/get", (req, res) => {
+  const getLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
+  router.get("/get", getLimiter, (req, res) => {
     const id = req.query.id;
     if (!id || Array.isArray(id)) {
       res.sendStatus(400);


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/TI-32.Nameless/security/code-scanning/2](https://github.com/NanashiTheNameless/TI-32.Nameless/security/code-scanning/2)

To address the issue, we will use the `express-rate-limit` package to apply rate limiting to the `/get` endpoint. This middleware will restrict the number of requests a client can make within a specified time window. The fix involves:

1. Installing the `express-rate-limit` package.
2. Importing the package in the file.
3. Configuring a rate limiter with appropriate settings (e.g., maximum requests per minute).
4. Applying the rate limiter middleware to the `/get` route.

This approach ensures that the `/get` endpoint is protected against abuse while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
